### PR TITLE
Open log file for append.

### DIFF
--- a/clog_file.go
+++ b/clog_file.go
@@ -111,7 +111,14 @@ func create(tag string, t time.Time) (f *os.File, filename string, err error) {
 	var lastErr error
 	for _, dir := range logDirs {
 		fname := filepath.Join(dir, name)
-		f, err := os.Create(fname)
+
+		// Open the file os.O_APPEND|os.O_CREATE rather than use os.Create.
+		// Append is almost always more efficient than O_RDRW on most modern file systems.
+		f, err = os.OpenFile(fname, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0664)
+		if err != nil {
+			return nil, "", fmt.Errorf("log: cannot create log: %v", err)
+		}
+
 		if err == nil {
 			symlink := filepath.Join(dir, link)
 			os.Remove(symlink)        // ignore err


### PR DESCRIPTION
This originally came out of this investigation:
https://corner.squareup.com/2014/09/logging-can-be-tricky.html

The fsync issue isn't there in this version of the code but the append flag issue was.

- OS and FS don't need to keep the overhead of a seek cursor for the fd.
- O_Append also plays better if ever an external file rotator gets run on the host.

    e.g.:
    - a logger with a file opened RW is several gigs into a log file
    - external rotator kicks in but the fs's seek cursor is still X gigs into the file
    - new file on disk is written sparsely with gigs of \0 bytes.